### PR TITLE
chore(release): patch bump all packages

### DIFF
--- a/.changeset/patch-all-packages.md
+++ b/.changeset/patch-all-packages.md
@@ -1,0 +1,16 @@
+---
+"bunli": patch
+"@bunli/core": patch
+"@bunli/generator": patch
+"@bunli/plugin-ai-detect": patch
+"@bunli/plugin-completions": patch
+"@bunli/plugin-config": patch
+"@bunli/plugin-mcp": patch
+"@bunli/test": patch
+"@bunli/tui": patch
+"@bunli/utils": patch
+"create-bunli": patch
+---
+
+Patch bump all publishable packages to validate the full Changesets-driven release pipeline:
+npm publish, version PR flow, and the dispatched `bunli@*` GitHub binary release.


### PR DESCRIPTION
Adds a single Changeset that bumps every publishable package by a patch to validate the full release pipeline (Version Packages PR -> npm publish -> dispatch binaries GitHub Release).\n\nAfter merging this PR, merge the automated Version Packages PR to publish.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aryalabshq/bunli/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
