### PR TITLE
fix(release): publish without workspace:* deps

### DIFF
--- a/.changeset/fix-workspace-protocol-publish.md
+++ b/.changeset/fix-workspace-protocol-publish.md
@@ -1,0 +1,15 @@
+---
+"bunli": patch
+"@bunli/core": patch
+"@bunli/generator": patch
+"@bunli/plugin-ai-detect": patch
+"@bunli/plugin-completions": patch
+"@bunli/plugin-config": patch
+"@bunli/plugin-mcp": patch
+"@bunli/test": patch
+"@bunli/tui": patch
+"@bunli/utils": patch
+"create-bunli": patch
+---
+
+Fix npm releases by rewriting `workspace:*` internal dependency ranges to real semver ranges at publish time.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,6 +40,12 @@ Useful flags:
 The repo uses `changesets/action` to keep a Version Packages PR up to date.
 When the Version Packages PR is merged, CI will publish packages to npm.
 
+### Workspace protocol note
+
+Inside the monorepo, packages depend on each other via `workspace:*`.
+Before publishing to npm, we rewrite those ranges to real semver ranges so consumers can install
+with npm or Bun. This happens automatically in CI as part of `release:publish`.
+
 ### Required GitHub secrets
 
 - `NPM_TOKEN`: used by the publish step to publish to npm.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "changeset:version": "bunx changeset version",
     "changeset:publish": "bunx changeset publish",
     "release:prepare": "bun scripts/release-prepare.ts",
-    "release:publish": "bun run build && bunx changeset publish"
+    "release:publish": "bun run build && bun scripts/resolve-workspace-deps.ts --write && bunx changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",

--- a/scripts/resolve-workspace-deps.ts
+++ b/scripts/resolve-workspace-deps.ts
@@ -1,0 +1,134 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+type PackageJson = {
+  name?: string
+  version?: string
+  private?: boolean
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+}
+
+type DepSection = keyof Pick<
+  PackageJson,
+  'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies'
+>
+
+function parseArgs(argv: string[]) {
+  const args = new Set(argv)
+  const write = args.has('--write')
+  const verbose = args.has('--verbose')
+
+  for (const a of args) {
+    if (!a.startsWith('--')) continue
+    if (a === '--write' || a === '--verbose') continue
+    throw new Error(`Unknown flag: ${a}`)
+  }
+
+  return { write, verbose }
+}
+
+function resolveWorkspaceRange(workspaceValue: string, resolvedVersion: string) {
+  const suffix = workspaceValue.slice('workspace:'.length)
+  if (suffix === '*' || suffix === '') return resolvedVersion
+  if (suffix === '^') return `^${resolvedVersion}`
+  if (suffix === '~') return `~${resolvedVersion}`
+  // Be conservative: if someone starts using advanced workspace protocols,
+  // fail fast rather than silently publishing an invalid range.
+  throw new Error(`Unsupported workspace protocol: ${workspaceValue}`)
+}
+
+async function readJson(filePath: string): Promise<PackageJson> {
+  const raw = await readFile(filePath, 'utf8')
+  return JSON.parse(raw) as PackageJson
+}
+
+async function main() {
+  const { write, verbose } = parseArgs(process.argv.slice(2))
+
+  const repoRoot = process.cwd()
+  const packagesDir = path.join(repoRoot, 'packages')
+
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const packageJsonPaths = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(packagesDir, e.name, 'package.json'))
+
+  const nameToVersion = new Map<string, string>()
+  const pkgInfos: Array<{ filePath: string; json: PackageJson }> = []
+
+  for (const filePath of packageJsonPaths) {
+    const json = await readJson(filePath)
+    if (!json.name || !json.version) continue
+    nameToVersion.set(json.name, json.version)
+    pkgInfos.push({ filePath, json })
+  }
+
+  const sections: DepSection[] = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ]
+
+  const changedFiles: string[] = []
+
+  for (const pkg of pkgInfos) {
+    if (pkg.json.private) continue
+
+    let changed = false
+    const next: PackageJson = structuredClone(pkg.json)
+
+    for (const section of sections) {
+      const deps = next[section]
+      if (!deps) continue
+
+      for (const [depName, depRange] of Object.entries(deps)) {
+        if (!depRange.startsWith('workspace:')) continue
+
+        const resolved = nameToVersion.get(depName)
+        if (!resolved) {
+          throw new Error(
+            `Unresolved workspace dependency ${depName} in ${pkg.filePath} (${section}: ${depRange})`,
+          )
+        }
+
+        deps[depName] = resolveWorkspaceRange(depRange, resolved)
+        changed = true
+      }
+    }
+
+    if (!changed) continue
+
+    const raw = JSON.stringify(next, null, 2) + '\n'
+    if (write) {
+      await writeFile(pkg.filePath, raw, 'utf8')
+    }
+
+    changedFiles.push(pkg.filePath)
+    if (verbose) {
+      // eslint-disable-next-line no-console
+      console.log(`rewrote workspace deps: ${path.relative(repoRoot, pkg.filePath)}`)
+    }
+  }
+
+  if (changedFiles.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log('no workspace protocol dependencies found in publishable packages')
+    return
+  }
+
+  if (!write) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `dry run: would rewrite workspace protocol dependencies in ${changedFiles.length} package.json files. Re-run with --write.`,
+    )
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`rewrote workspace protocol dependencies in ${changedFiles.length} package.json files`)
+  }
+}
+
+await main()


### PR DESCRIPTION
Fixes npm releases: packages currently publish internal deps as 'workspace:*', which breaks installs via npm and bun (see #7).\n\nThis PR keeps workspace:* in the repo for development, but rewrites workspace protocol ranges to real semver ranges right before 'changeset publish' (CI publish path).\n\nIncludes a patch changeset to republish all packages with corrected dependency ranges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aryalabshq/bunli/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
