### PR TITLE
refactor(release): publish via bun publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,28 +37,26 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: bun run changeset:version
-          publish: bun run release:publish
+          version: bun run ci:version
+          publish: bun run ci:publish
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dispatch Binary Release
-        if: steps.changesets.outputs.published == 'true'
         uses: actions/github-script@v7
-        env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         with:
           script: |
-            const publishedRaw = process.env.PUBLISHED_PACKAGES || "[]";
-            let published;
-            try {
-              published = JSON.parse(publishedRaw);
-            } catch {
-              core.warning(`Failed to parse publishedPackages: ${publishedRaw}`);
-              published = [];
+            const fs = require("fs");
+            const publishedPath = ".changeset/published-packages.json";
+            if (!fs.existsSync(publishedPath)) {
+              core.info("No published packages file found; skipping binary release dispatch.");
+              return;
             }
+
+            const publishedRaw = fs.readFileSync(publishedPath, "utf8");
+            const published = JSON.parse(publishedRaw || "[]");
 
             const cli = published.find((p) => p?.name === "bunli");
             if (!cli?.version) {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,6 +40,9 @@ Useful flags:
 The repo uses `changesets/action` to keep a Version Packages PR up to date.
 When the Version Packages PR is merged, CI will publish packages to npm.
 
+Publishing uses `bun publish` (not `npm publish`) so workspace dependencies like `workspace:*`
+are correctly resolved into real semver ranges in the published tarballs.
+
 ### Required GitHub secrets
 
 - `NPM_TOKEN`: used by the publish step to publish to npm.

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "release": "bun run release:prepare",
     "changeset": "bunx changeset",
     "changeset:version": "bunx changeset version",
-    "changeset:publish": "bunx changeset publish",
+    "changeset:publish": "bun run ci:publish",
     "release:prepare": "bun scripts/release-prepare.ts",
-    "release:publish": "bun run build && bunx changeset publish"
+    "ci:version": "bun scripts/ci-version.ts",
+    "ci:publish": "bun scripts/ci-publish.ts",
+    "release:publish": "bun run build && bun run ci:publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",

--- a/scripts/ci-publish.ts
+++ b/scripts/ci-publish.ts
@@ -1,0 +1,128 @@
+import { $ } from 'bun'
+import { readdir, readFile, writeFile, mkdir, appendFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+type PublishedPackage = { name: string; version: string }
+
+const REGISTRY = 'https://registry.npmjs.org'
+
+async function ensureNpmAuth() {
+  const token = process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN
+  if (!token) {
+    throw new Error('Missing NPM_TOKEN (or NODE_AUTH_TOKEN) in environment')
+  }
+
+  const npmrcPath = path.join(os.homedir(), '.npmrc')
+  const line = `//registry.npmjs.org/:_authToken=${token}\n`
+
+  // Avoid clobbering user configs; in CI this is typically empty anyway.
+  if (existsSync(npmrcPath)) {
+    const existing = await readFile(npmrcPath, 'utf8')
+    if (existing.includes('_authToken=')) return
+    await appendFile(npmrcPath, line)
+    return
+  }
+
+  await writeFile(npmrcPath, line, 'utf8')
+}
+
+async function versionExistsOnNpm(name: string, version: string): Promise<boolean> {
+  const url = `${REGISTRY}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`
+  const res = await fetch(url, {
+    headers: {
+      // Faster payload shape and less metadata.
+      accept: 'application/vnd.npm.install-v1+json'
+    }
+  })
+
+  if (res.status === 404) return false
+  if (res.ok) return true
+
+  const body = await res.text().catch(() => '')
+  throw new Error(`Failed to query npm registry for ${name}@${version}: ${res.status} ${res.statusText}${body ? `\n${body}` : ''}`)
+}
+
+async function readJson(filePath: string) {
+  return JSON.parse(await readFile(filePath, 'utf8'))
+}
+
+async function listPublishablePackages(): Promise<Array<{ dir: string; name: string; version: string }>> {
+  const packagesRoot = path.join(process.cwd(), 'packages')
+  const entries = await readdir(packagesRoot, { withFileTypes: true })
+
+  const pkgs: Array<{ dir: string; name: string; version: string }> = []
+
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue
+
+    const dir = path.join(packagesRoot, ent.name)
+    const pkgPath = path.join(dir, 'package.json')
+    if (!existsSync(pkgPath)) continue
+
+    const pkg = await readJson(pkgPath)
+    if (pkg.private) continue
+
+    const name = String(pkg.name || '')
+    const version = String(pkg.version || '')
+    if (!name || !version) {
+      throw new Error(`Invalid package.json in ${dir}: missing name or version`)
+    }
+
+    pkgs.push({ dir, name, version })
+  }
+
+  pkgs.sort((a, b) => a.name.localeCompare(b.name))
+  return pkgs
+}
+
+async function publishPackage(dir: string) {
+  // `--no-save` prevents bun.lockb or package.json modifications during publish.
+  // `--frozen-lockfile` ensures the lockfile committed in the Version Packages PR is honored.
+  // `--ignore-scripts` avoids re-running builds since CI already ran `bun run build`.
+  await $`bun publish --cwd ${dir} --access public --tag latest --no-save --frozen-lockfile --ignore-scripts`
+}
+
+async function writePublishedFile(published: PublishedPackage[]) {
+  const outDir = path.join(process.cwd(), '.changeset')
+  await mkdir(outDir, { recursive: true })
+  const outPath = path.join(outDir, 'published-packages.json')
+  await writeFile(outPath, JSON.stringify(published, null, 2) + '\n', 'utf8')
+}
+
+async function main() {
+  await ensureNpmAuth()
+
+  const pkgs = await listPublishablePackages()
+  const published: PublishedPackage[] = []
+
+  for (const pkg of pkgs) {
+    const exists = await versionExistsOnNpm(pkg.name, pkg.version)
+    if (exists) {
+      console.log(`skip ${pkg.name}@${pkg.version} (already on npm)`)
+      continue
+    }
+
+    console.log(`publish ${pkg.name}@${pkg.version}`)
+    await publishPackage(pkg.dir)
+    published.push({ name: pkg.name, version: pkg.version })
+  }
+
+  await writePublishedFile(published)
+
+  if (published.length === 0) {
+    console.log('No packages published.')
+    return
+  }
+
+  // Create per-package tags like `pkg@x.y.z`.
+  await $`bunx changeset tag`
+  if (process.env.CI) {
+    await $`git push origin --tags`
+  } else {
+    console.log('Skipping tag push because CI is not set.')
+  }
+}
+
+await main()

--- a/scripts/ci-version.ts
+++ b/scripts/ci-version.ts
@@ -1,0 +1,17 @@
+import { $ } from 'bun'
+
+/**
+ * CI helper used by `changesets/action` for the "Version Packages" PR.
+ *
+ * Changesets bumps package.json versions, but Bun needs an updated bun.lockb so that
+ * `bun publish` can correctly resolve workspace dependencies at publish time.
+ */
+async function main() {
+  // Ensure Changesets runs non-interactively in CI.
+  await $`CI=1 bunx changeset version`
+
+  // Intentionally allow lockfile changes here; the Version Packages PR should include bun.lockb updates.
+  await $`bun install`
+}
+
+await main()


### PR DESCRIPTION
Switch Changesets CI publishing to `bun publish` so workspace:* deps are resolved correctly (per https://ianm.com/posts/2025-08-18-setting-up-changesets-with-bun-workspaces).\n\nKey changes:\n- changesets/action uses `ci:version` and `ci:publish`\n- publish step scans `packages/*` and publishes via bun\n- writes `.changeset/published-packages.json` for binary release dispatch\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aryalabshq/bunli/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
