### PR TITLE
chore(ci): pin bun 1.3.8

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.8
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.8
       
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
Pin Bun to 1.3.8 in CI to avoid older bun publish behavior (runner logs show bun publish v1.3.0). This should also fix npm auth detection for bun publish.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aryalabshq/bunli/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
